### PR TITLE
feat: Add minutes_remaining field to TenantAdminForm

### DIFF
--- a/omni_pro_oms/admin/tenant.py
+++ b/omni_pro_oms/admin/tenant.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 from omni_pro_base.admin import BaseAdmin
@@ -6,7 +7,15 @@ from omni_pro_oms.models import Tenant
 
 
 class TenantAdmin(BaseAdmin):
-    list_display = ("name", "description", "code", "client_id", "client_secret")
+    list_display = (
+        "name",
+        "description",
+        "code",
+        "client_id",
+        "client_secret",
+        "minutes_remaining",
+        "token_expires_at",
+    )
     search_fields = ("name", "code")
     form = TenantAdminForm
 
@@ -24,6 +33,8 @@ class TenantAdmin(BaseAdmin):
                         "client_secret",
                         "base_url",
                         "token",
+                        "token_expires_at",
+                        "minutes_remaining",
                     )
                 },
             ),

--- a/omni_pro_oms/admin/tenant.py
+++ b/omni_pro_oms/admin/tenant.py
@@ -1,4 +1,3 @@
-from django import forms
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 from omni_pro_base.admin import BaseAdmin

--- a/omni_pro_oms/core/api_client.py
+++ b/omni_pro_oms/core/api_client.py
@@ -63,7 +63,7 @@ class ApiClient:
     def get_auth_token(self):
         if (
             self.tenant.token_expires_at
-            and (self.tenant.token_expires_at - datetime.now(timezone.utc)).total_seconds() > 300
+            and (self.tenant.token_expires_at - datetime.now(timezone.utc)).total_seconds() > 600
         ):
             return self.tenant.token
 

--- a/omni_pro_oms/forms/tenant.py
+++ b/omni_pro_oms/forms/tenant.py
@@ -1,9 +1,17 @@
 from django import forms
-
 from omni_pro_oms.models import Tenant
 
 
 class TenantAdminForm(forms.ModelForm):
+    minutes_remaining = forms.CharField(
+        label="Minutes Remaining", required=False, widget=forms.TextInput(attrs={"disabled": "disabled"})
+    )
+
     class Meta:
         model = Tenant
         fields = "__all__"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance:
+            self.fields["minutes_remaining"].initial = self.instance.minutes_remaining

--- a/omni_pro_oms/forms/tenant.py
+++ b/omni_pro_oms/forms/tenant.py
@@ -6,6 +6,7 @@ class TenantAdminForm(forms.ModelForm):
     minutes_remaining = forms.CharField(
         label="Minutes Remaining", required=False, widget=forms.TextInput(attrs={"disabled": "disabled"})
     )
+    token = forms.CharField(label="Token", required=False, widget=forms.Textarea(attrs={"disabled": "disabled"}))
 
     class Meta:
         model = Tenant

--- a/omni_pro_oms/models/tenant.py
+++ b/omni_pro_oms/models/tenant.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from auditlog.models import AuditlogHistoryField
 from auditlog.registry import auditlog
 from django.db import models
@@ -16,6 +18,12 @@ class Tenant(OmniModel):
     token_expires_at = models.DateTimeField(verbose_name=_("Token Expires At"), blank=True, null=True)
 
     history = AuditlogHistoryField()
+
+    @property
+    def minutes_remaining(self):
+        if self.token_expires_at:
+            remaining_time = self.token_expires_at - datetime.now(timezone.utc)
+            return remaining_time.total_seconds() // 60
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
This commit adds the `minutes_remaining` field to the `TenantAdminForm` in the `omni_pro_oms/forms/tenant.py` file. The field is a CharField with the label "Minutes Remaining" and is initially disabled. It allows the display of the remaining minutes until the token expires for a tenant.

The code changes include modifications to the `TenantAdmin` class in the `omni_pro_oms/admin/tenant.py` file. The `list_display` attribute is updated to include the `minutes_remaining` and `token_expires_at` fields.

The commit message follows the established convention of starting with a type prefix (`feat`) to indicate a new feature. It provides a clear and concise description of the purpose of the code changes.