### PR TITLE
feat(order): add raw_response option to OrderApi initialization

### DIFF
--- a/omni_pro_oms/core/sale/order.py
+++ b/omni_pro_oms/core/sale/order.py
@@ -3,13 +3,24 @@ from omni_pro_oms.core.api_client import ApiClient
 
 
 class OrderApi:
-    def __init__(self, api_client: ApiClient):
+    def __init__(self, api_client: ApiClient, raw_response=False):
         self.api_client = api_client
+        self.raw_response = raw_response
 
     def get_api(self, **kwargs):
-        data = self.api_client.call_api(method="GET", endpoint=endpoint_order, **kwargs)
-        return data.get("orders")
+        try:
+            data = self.api_client.call_api(method="GET", endpoint=endpoint_order, **kwargs)
+            if self.raw_response:
+                return data
+            return data.get("orders")
+        except Exception as e:
+            raise {"error": str(e)}
 
     def put_api(self, **kwargs):
-        data = self.api_client.call_api(method="PUT", endpoint=endpoint_order, **kwargs)
-        return data.get("order")
+        try:
+            data = self.api_client.call_api(method="PUT", endpoint=endpoint_order, **kwargs)
+            if self.raw_response:
+                return data
+            return data.get("order")
+        except Exception as e:
+            raise {"error": str(e)}


### PR DESCRIPTION
This commit adds a new parameter, `raw_response`, to the `__init__` method of the `OrderApi` class. This parameter allows the user to specify whether they want to receive the raw response from the API or just the orders or order data.

The `get_api` and `put_api` methods have been updated to handle the `raw_response` parameter. If `raw_response` is set to `True`, the methods will return the full response from the API. Otherwise, they will return just the orders or order data.

This change improves the flexibility of the `OrderApi` class and allows users to retrieve the raw response if needed.