### PR TITLE
NVOMS-3030 - Quitar la atenticación inetrena CORE a Django y Django a CORE

### DIFF
--- a/omni_pro_oms/views/base.py
+++ b/omni_pro_oms/views/base.py
@@ -1,6 +1,10 @@
 from omni_pro_oms.permissions import TokenValidScope
-from rest_framework import views
+from rest_framework import permissions, views
 
 
 class OMNIAPIView(views.APIView):
     permission_classes = [TokenValidScope]
+
+
+class InternalBaseView(views.APIView):
+    permission_classes = [permissions.AllowAny]


### PR DESCRIPTION
# NVOMS-3030 - Quitar la atenticación inetrena CORE a Django y Django a CORE

## ref NVOMS-3030 https://omnipro.atlassian.net/browse/NVOMS-3030 

## Descripción
Este PR agrega la clase InternalBaseView en base.py de la libreria app oms.

## Cambios
- Se creo la clase InternalBaseView para definir permisos en las clases.

## Motivación y contexto
N/A

## Cómo se ha probado
-  Se compilo la nueva versión de la libreria y se hicieron pruebas del lado de las apps.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A