### PR TITLE
NVOMS-3151- Priorizar el envío de ordenes en una cola diferente para evitar esos retrasos

### DIFF
--- a/omni_pro_oms/models/operation.py
+++ b/omni_pro_oms/models/operation.py
@@ -32,6 +32,16 @@ class Operation(OmniModel):
         AUTH1 = "auth1"
         CUSTOM = "custom"
 
+    SCORE_PRIORITY_MAP = {
+        "low": 1,
+        "medium": 5,
+        "high": 9,
+        "critical": 10,
+    }
+
+    def get_score_priority(self):
+        return self.SCORE_PRIORITY_MAP.get(self.score)
+
     name = models.CharField(max_length=255, verbose_name=_("Name"))
     destination = models.CharField(max_length=255, verbose_name=_("Destination"))
     score = models.CharField(


### PR DESCRIPTION
# NVOMS-3151- Priorizar el envío de ordenes en una cola diferente para evitar esos retrasos

## ref NVOMS-3151 https://omnipro.atlassian.net/browse/NVOMS-3151

## Descripción
- Este PR agrega el mapeo del campo score de operations en numeros para poder ser legible por celery.

## Cambios
- Añadido el mapeo del campo score de operations en numeros para poder ser legible por celery y poderlo utilizar del lado de la operación en la app.

## Motivación y contexto
Estos cambios son necesarios para priorizar tareas.

## Cómo se ha probado
-  Se realizaron pruebas compilando la nueva versión de la librería.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [ ]  Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A