### PR TITLE
Add notifications management to Operation model and Task admin

### DIFF
--- a/omni_pro_oms/admin/operation.py
+++ b/omni_pro_oms/admin/operation.py
@@ -26,6 +26,16 @@ class OperationAdmin(BaseAdmin):
                 _("Clean Task"),
                 {"fields": ("success_clean_task_days", "other_clean_task_days", "packages_to_clean_count")},
             ),
+            (
+                _("Notifications"),
+                {
+                    "fields": (
+                        "active_notifications",
+                        "emails",
+                        "status_notifications",
+                    )
+                },
+            ),
         ) + self.fieldsets
 
 

--- a/omni_pro_oms/admin/task.py
+++ b/omni_pro_oms/admin/task.py
@@ -126,5 +126,19 @@ class TaskAdmin(ImportExportModelAdmin, BaseAdmin):
 
     actions = [retry_task]
 
+    def save_model(self, request, obj, form, change):
+        """
+        Overrides the save_model method to set a custom attribute before saving the model.
+        Args:
+            request (HttpRequest): The current request object.
+            obj (Model): The model instance being saved.
+            form (ModelForm): The form instance used to create or update the model.
+            change (bool): A flag indicating whether the model is being changed (True) or added (False).
+        """
+
+        if change:
+            obj._admin_panel = True
+        super().save_model(request, obj, form, change)
+
 
 admin.site.register(Task, TaskAdmin)

--- a/omni_pro_oms/apps.py
+++ b/omni_pro_oms/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class OmsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "omni_pro_oms"
+
+    def ready(self):
+        import omni_pro_oms.models.signals
+
+        return super().ready()

--- a/omni_pro_oms/forms/operation.py
+++ b/omni_pro_oms/forms/operation.py
@@ -1,13 +1,22 @@
 from django import forms
+from django.contrib.postgres.forms import SimpleArrayField
 from django_json_widget.widgets import JSONEditorWidget
-
 from omni_pro_oms.models import Operation
 
 
 class OperationAdminForm(forms.ModelForm):
+    emails = SimpleArrayField(forms.EmailField(), required=False, widget=forms.Textarea(attrs={"rows": 4, "cols": 20}))
+
     class Meta:
         model = Operation
         fields = "__all__"
         widgets = {
             "headers": JSONEditorWidget,
         }
+
+    def clean_emails(self):
+        emails = self.cleaned_data.get("emails", [])
+        # Validate if emails are unique
+        if len(emails) != len(set(emails)):
+            raise forms.ValidationError("Duplicate emails are not allowed.")
+        return emails

--- a/omni_pro_oms/models/operation.py
+++ b/omni_pro_oms/models/operation.py
@@ -1,8 +1,16 @@
 from auditlog.models import AuditlogHistoryField
 from auditlog.registry import auditlog
+from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from omni_pro_base.models import OmniModel
+
+STATUS_CHOICES = (
+    ("waiting", "Waiting"),
+    ("error", "Error"),
+    ("success", "Success"),
+    ("partial_success", "Partial Success"),
+)
 
 
 class Operation(OmniModel):
@@ -50,6 +58,14 @@ class Operation(OmniModel):
     )
     packages_to_clean_count = models.IntegerField(
         verbose_name=_("Packages To Clean Count"), help_text=_("Number of packages to clean"), null=True, blank=True
+    )
+    active_notifications = models.BooleanField(verbose_name=_("Active Notifications"), default=False)
+    emails = ArrayField(models.EmailField(), blank=True, default=list, verbose_name=_("Emails"))
+    status_notifications = models.CharField(
+        choices=STATUS_CHOICES,
+        max_length=256,
+        default="error",
+        verbose_name=_("Status Notifications"),
     )
 
     history = AuditlogHistoryField()

--- a/omni_pro_oms/models/signals.py
+++ b/omni_pro_oms/models/signals.py
@@ -1,0 +1,76 @@
+from django.conf import settings
+from django.core.mail import send_mail
+from django.db.models.signals import post_save, pre_save
+from django.dispatch import receiver
+from omni_pro_oms.models import Task
+
+
+@receiver(pre_save, sender=Task)
+def set_old_status(sender, instance, **kwargs):
+    """
+    Signal handler to set the old status of a Task instance before it is saved.
+    This function is intended to be connected to the pre-save signal of the Task model.
+    It checks if the instance being saved already exists in the database (i.e., it has a primary key).
+    If it does, it retrieves the current status of the instance from the database and stores it in the
+    instance's _old_status attribute. If the instance is new (i.e., it does not have a primary key yet),
+    it sets the _old_status attribute to None.
+    Args:
+        sender (Model): The model class that sent the signal.
+        instance (Model instance): The instance of the model that is being saved.
+        **kwargs: Additional keyword arguments.
+    """
+
+    if instance.pk:
+        old = Task.objects.filter(pk=instance.pk).values("status").first()
+        if old:
+            instance._old_status = old["status"]  # Save the previous status
+        else:
+            instance._old_status = None
+    else:
+        instance._old_status = None
+
+
+@receiver(post_save, sender=Task)
+def send_email_on_error_status(sender, instance, created, **kwargs):
+    """
+    Sends an email notification when the status of an instance changes to a specific value.
+    This function is intended to be used as a Django signal handler for the post_save signal.
+    It sends an email notification only when the instance is updated (not created) and the status
+    changes to a specific value defined in the related operation_id.
+    Args:
+        sender (Model): The model class that sent the signal.
+        instance (Model instance): The actual instance being saved.
+        created (bool): A boolean indicating whether a new record was created.
+        **kwargs: Additional keyword arguments.
+    Conditions for sending an email:
+        - The instance is not newly created.
+        - The old status is different from the new status.
+        - The new status matches the status_notifications of the related operation_id.
+        - The related operation_id has active notifications.
+        - The related operation_id has specified email addresses.
+        - The update is not performed from the admin panel.
+    Email content:
+        - Subject: Status change notification with the task name and ID.
+        - Message: Details about the task and its new status.
+        - Recipients: Email addresses specified in the related operation_id.
+    """
+
+    # We avoid emails during creation, only for updates
+    if not created:
+        old_status = getattr(instance, "_old_status", None)
+        new_status = instance.status
+        admin_panel = getattr(instance, "_admin_panel", False)
+
+        if (
+            old_status != instance.operation_id.status_notifications
+            and new_status == instance.operation_id.status_notifications
+            and instance.operation_id.active_notifications
+            and instance.operation_id.emails
+            and not admin_panel
+        ):
+            status: str = instance.operation_id.status_notifications
+            asunto = f"{status.capitalize()} en tarea {instance.name} con ID {instance.pk}"
+            mensaje = f"La tarea {instance.name} con ID {instance.pk} ha pasado a estado de {status}."
+            destinatarios = instance.operation_id.emails
+
+            send_mail(asunto, mensaje, settings.DEFAULT_FROM_EMAIL, destinatarios, fail_silently=False)


### PR DESCRIPTION
# Crear notificaciones de Django en tareas con estado fallido u otros

## ref https://omnipro.atlassian.net/browse/NVOMS-3182


## Descripción
Se agregan campos para el modelo de Operation. Se establece un atributo personalizado durante el guardado del modelo de Task en su AdminPanel. Se implementaron controladores de señales para Task para gestionar cambios de estado y enviar notificaciones por correo electrónico según


Tener en cuenta que las actualizaciones en el PaneldeAdmin no activan el envió de los correos, también solo pasa cuando una Task es actualizada , no ocurre cuando es creada 

## Cambios
- Se introdujeron campos para notificaciones activas, correos electrónicos y notificaciones de estado en el modelo de Operación.
- OperationAdminForm actualizado para manejar la validación de correo electrónico y permitir múltiples entradas de correo electrónico.
- TaskAdmin mejorado para establecer un atributo personalizado durante el guardado del modelo.
- Se implementaron controladores de señales para Task para gestionar cambios de estado y enviar notificaciones por correo electrónico según condiciones específicas.

## Cómo se ha probado
- Pruebas con los campos
- Se comprobó la llegada del correo
- Se comprobo que los PanelAdmin sigan en correcto funcionamiento

## Uso
Para el uso de estos cambios se tiene que actualizar el Operation, para activar las notificaciones, agregar emails y elegir un Estado al cual se va ser de activador para el envió del correo


## Screenshots (si aplica)
![image](https://github.com/user-attachments/assets/55fd1e84-854a-4d61-9cdf-70145cfe1050)


## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
Estos cambios conllevan migraciones