### PR TITLE
feat: Controlar retry automático únicamente cuando el estado cambia explícitamente a "waiting" NVOMS-3507 / NVOMS-2912

### DIFF
--- a/omni_pro_oms/task/task_api.py
+++ b/omni_pro_oms/task/task_api.py
@@ -62,7 +62,7 @@ class TaskApi(ApiClient):
         self.task.time = time_request
         self.task.status = self.get_task_status_from_request_status_code([response.status_code])
         self.task.item = item
-        self.task.save()
+        self.task.save(update_fields=["url_dst", "headers_dst", "body_dst", "response_dst", "time", "status", "item"])
 
     def _update_celery_task_id(self, celery_task_id: str) -> None:
         """Actualiza el ID de la tarea de Celery en el modelo Task."""


### PR DESCRIPTION
# NVOMS-3507 - Controlar retry automático únicamente cuando el estado cambia explícitamente a "waiting"

## ref https://omnipro.atlassian.net/browse/NVOMS-3507

## Descripción
Este PR centraliza y corrige la lógica de reintentos automáticos (`retry`) en las tareas (`Task`), para que solo se ejecute cuando se actualiza explícitamente el campo `status` a `"waiting"`. También se refactoriza el admin para usar la nueva función `retry_task_single()` desde `utils.py`.

## Cambios
- **Librería Base:**
  - Se actualiza el método `save()` del modelo `Task` para ejecutar `retry_operation()` solo si:
    - El objeto ya existe (`not is_new`).
    - El valor anterior del campo `status` es distinto.
    - El nuevo estado es `"waiting"`.
- **Librería OMS:**
  - `task_update_from_response()` ahora utiliza `update_fields` para que el `save()` detecte correctamente si el campo `status` ha sido modificado.
  - Se mueve la lógica de reintento del método `retry_task()` en `TaskAdmin` hacia la función `retry_task_single()` ubicada en `utils.py`, eliminando duplicación y permitiendo reutilización.

## Motivación y contexto
- El sistema ejecutaba el reintento automático incluso cuando el estado no cambiaba, lo cual generaba bucles innecesarios y llamadas repetidas.
- Este cambio previene ejecuciones erróneas y mejora la trazabilidad y control del retry desde un solo punto lógico.

## Cómo se ha probado
- Se probaron actualizaciones de tareas cambiando y no cambiando el estado `status`.
- Se verificó que el retry solo ocurre cuando el estado cambia explícitamente a `"waiting"`.
- Se validó que el `admin` ejecute correctamente `retry_task_single()` desde `utils.py`.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
- Este cambio mantiene la compatibilidad con llamadas desde vistas, Celery y el admin, sin necesidad de agregar campos nuevos ni utilizar flags en memoria.